### PR TITLE
Support 0x4 type in BHE

### DIFF
--- a/evm/gas/block_history_estimator.go
+++ b/evm/gas/block_history_estimator.go
@@ -917,7 +917,7 @@ func (b *BlockHistoryEstimator) EffectiveGasPrice(block evmtypes.Block, tx evmty
 	switch tx.Type {
 	case 0x0, 0x1:
 		return tx.GasPrice
-	case 0x2, 0x3:
+	case 0x2, 0x3, 0x4:
 		return b.getEffectiveGasPrice(block, tx)
 	default:
 		b.logger.Debugw(fmt.Sprintf("Ignoring unknown transaction type %v", tx.Type), "block", block, "tx", tx)
@@ -955,7 +955,7 @@ func (b *BlockHistoryEstimator) getEffectiveGasPrice(block evmtypes.Block, tx ev
 
 func (b *BlockHistoryEstimator) EffectiveTipCap(block evmtypes.Block, tx evmtypes.Transaction) *assets.Wei {
 	switch tx.Type {
-	case 0x2, 0x3:
+	case 0x2, 0x3, 0x4:
 		return tx.MaxPriorityFeePerGas
 	case 0x0, 0x1:
 		if tx.GasPrice == nil {

--- a/evm/gas/block_history_estimator_test.go
+++ b/evm/gas/block_history_estimator_test.go
@@ -1515,7 +1515,7 @@ func TestBlockHistoryEstimator_EffectiveTipCap(t *testing.T) {
 		res := bhe.EffectiveTipCap(eipblock, tx)
 		assert.Equal(t, "42 wei", res.String())
 	})
-	t.Run("tx type 2 & type 3 should calculate gas price", func(t *testing.T) {
+	t.Run("tx type 2, 3, and 4 should calculate gas price", func(t *testing.T) {
 		// 0x2 transaction (should use MaxPriorityFeePerGas)
 		tx := evmtypes.Transaction{Type: 0x2, MaxPriorityFeePerGas: assets.NewWeiI(200), MaxFeePerGas: assets.NewWeiI(250), GasLimit: 42, Hash: utils.NewHash()}
 		res := bhe.EffectiveTipCap(eipblock, tx)
@@ -1533,6 +1533,15 @@ func TestBlockHistoryEstimator_EffectiveTipCap(t *testing.T) {
 		tx = evmtypes.Transaction{Type: 0x3, GasPrice: assets.NewWeiI(400), MaxPriorityFeePerGas: assets.NewWeiI(100), MaxFeePerGas: assets.NewWeiI(350), GasLimit: 42, Hash: utils.NewHash()}
 		res = bhe.EffectiveTipCap(eipblock, tx)
 		assert.Equal(t, "100 wei", res.String())
+
+		// 0x4 transaction (should use MaxPriorityFeePerGas)
+		tx = evmtypes.Transaction{Type: 0x4, MaxPriorityFeePerGas: assets.NewWeiI(100), MaxFeePerGas: assets.NewWeiI(250), GasLimit: 42, Hash: utils.NewHash()}
+		res = bhe.EffectiveTipCap(eipblock, tx)
+		assert.Equal(t, "100 wei", res.String())
+		// 0x4 transaction (should use MaxPriorityFeePerGas, ignoring gas price)
+		tx = evmtypes.Transaction{Type: 0x4, GasPrice: assets.NewWeiI(400), MaxPriorityFeePerGas: assets.NewWeiI(100), MaxFeePerGas: assets.NewWeiI(350), GasLimit: 42, Hash: utils.NewHash()}
+		res = bhe.EffectiveTipCap(eipblock, tx)
+		assert.Equal(t, "100 wei", res.String())
 	})
 	t.Run("missing field returns nil", func(t *testing.T) {
 		tx := evmtypes.Transaction{Type: 0x2, GasPrice: assets.NewWeiI(132), MaxFeePerGas: assets.NewWeiI(200), GasLimit: 42, Hash: utils.NewHash()}
@@ -1540,7 +1549,7 @@ func TestBlockHistoryEstimator_EffectiveTipCap(t *testing.T) {
 		assert.Nil(t, res)
 	})
 	t.Run("unknown type returns nil", func(t *testing.T) {
-		tx := evmtypes.Transaction{Type: 0x4, GasPrice: assets.NewWeiI(55555), MaxPriorityFeePerGas: assets.NewWeiI(200), MaxFeePerGas: assets.NewWeiI(250), GasLimit: 42, Hash: utils.NewHash()}
+		tx := evmtypes.Transaction{Type: 0x5, GasPrice: assets.NewWeiI(55555), MaxPriorityFeePerGas: assets.NewWeiI(200), MaxFeePerGas: assets.NewWeiI(250), GasLimit: 42, Hash: utils.NewHash()}
 		res := bhe.EffectiveTipCap(eipblock, tx)
 		assert.Nil(t, res)
 	})
@@ -1615,6 +1624,25 @@ func TestBlockHistoryEstimator_EffectiveGasPrice(t *testing.T) {
 		assert.Equal(t, "5 wei", res.String())
 	})
 
+	t.Run("tx type 4 should calculate gas price", func(t *testing.T) {
+		// 0x4 transaction (should calculate to 250)
+		tx := evmtypes.Transaction{Type: 0x4, MaxPriorityFeePerGas: assets.NewWeiI(100), MaxFeePerGas: assets.NewWeiI(110), GasLimit: 42, Hash: utils.NewHash()}
+		res := bhe.EffectiveGasPrice(eipblock, tx)
+		assert.Equal(t, "110 wei", res.String())
+		// 0x4 transaction (should calculate to 300)
+		tx = evmtypes.Transaction{Type: 0x4, MaxPriorityFeePerGas: assets.NewWeiI(200), MaxFeePerGas: assets.NewWeiI(350), GasLimit: 42, Hash: utils.NewHash()}
+		res = bhe.EffectiveGasPrice(eipblock, tx)
+		assert.Equal(t, "300 wei", res.String())
+		// 0x4 transaction (should calculate to 300, ignoring gas price)
+		tx = evmtypes.Transaction{Type: 0x4, MaxPriorityFeePerGas: assets.NewWeiI(200), MaxFeePerGas: assets.NewWeiI(350), GasLimit: 42, Hash: utils.NewHash()}
+		res = bhe.EffectiveGasPrice(eipblock, tx)
+		assert.Equal(t, "300 wei", res.String())
+		// 0x4 transaction (should fall back to gas price since MaxFeePerGas is missing)
+		tx = evmtypes.Transaction{Type: 0x4, GasPrice: assets.NewWeiI(5), MaxPriorityFeePerGas: assets.NewWeiI(200), GasLimit: 42, Hash: utils.NewHash()}
+		res = bhe.EffectiveGasPrice(eipblock, tx)
+		assert.Equal(t, "5 wei", res.String())
+	})
+
 	t.Run("tx type 2 has block missing base fee (should never happen but must handle gracefully)", func(t *testing.T) {
 		// 0x2 transaction (should calculate to 250)
 		tx := evmtypes.Transaction{Type: 0x2, GasPrice: assets.NewWeiI(55555), MaxPriorityFeePerGas: assets.NewWeiI(200), MaxFeePerGas: assets.NewWeiI(250), GasLimit: 42, Hash: utils.NewHash()}
@@ -1622,7 +1650,7 @@ func TestBlockHistoryEstimator_EffectiveGasPrice(t *testing.T) {
 		assert.Equal(t, "55.555 kwei", res.String())
 	})
 	t.Run("unknown type returns nil", func(t *testing.T) {
-		tx := evmtypes.Transaction{Type: 0x4, GasPrice: assets.NewWeiI(55555), MaxPriorityFeePerGas: assets.NewWeiI(200), MaxFeePerGas: assets.NewWeiI(250), GasLimit: 42, Hash: utils.NewHash()}
+		tx := evmtypes.Transaction{Type: 0x5, GasPrice: assets.NewWeiI(55555), MaxPriorityFeePerGas: assets.NewWeiI(200), MaxFeePerGas: assets.NewWeiI(250), GasLimit: 42, Hash: utils.NewHash()}
 		res := bhe.EffectiveGasPrice(block, tx)
 		assert.Nil(t, res)
 	})


### PR DESCRIPTION
This PR adds support to [EIP-7702](https://github.com/ethereum/EIPs/blob/d96625a4dcbbe2572fa006f062bd02b4582eefd5/EIPS/eip-7702.md) and the new 0x4 transaction type.