### PR TITLE
reduced bumpMin for Linea Mainnet

### DIFF
--- a/evm/config/toml/defaults/Linea_Mainnet.toml
+++ b/evm/config/toml/defaults/Linea_Mainnet.toml
@@ -6,6 +6,8 @@ LinkContractAddress = '0xa18152629128738a5c081eb226335FEd4B9C95e9'
 NoNewHeadsThreshold = '0'
 
 [GasEstimator]
+# bumping by 0.5 gwei to keep transaction cost in check
+BumpMin = '500 mwei'
 BumpPercent = 40
 PriceMin = '400 mwei'
 


### PR DESCRIPTION
Linea Mainnet NOPs are sending transactions with 5+ gwei when bumped, leading to higher overall costs. 
reducing to 0.5 gwei to avoid excessive bumping