### PR TITLE
Logpoller Latency Monitoring

### DIFF
--- a/evm/logpoller/latency_monitor.go
+++ b/evm/logpoller/latency_monitor.go
@@ -11,7 +11,10 @@ import (
 	"github.com/smartcontractkit/chainlink-integrations/evm/types"
 )
 
-const latencyWarningThreshold = 0.7 // Warn if latency exceeds 70% of block production rate
+const (
+	latencyWarningThreshold = 0.7 // Warn if latency exceeds 70% of block production rate
+	latencyWarning          = "RPC server is not meeting latency requirements"
+)
 
 type LatencyMonitorClient interface {
 	HeadByNumber(ctx context.Context, n *big.Int) (*types.Head, error)
@@ -48,8 +51,8 @@ func latencyMonitoredCall[T any](lmc *LatencyMonitor, name string, fn func() (T,
 	threshold := time.Duration(float64(lmc.blockProductionRate) * latencyWarningThreshold)
 	if latency > threshold {
 		lmc.lggr.Warnf(
-			"%s latency of %s exceeded threshold of %s (%.0f%% of block production time %s)",
-			name, latency, threshold, latencyWarningThreshold*100, lmc.blockProductionRate,
+			"%s: %s latency of %s exceeded threshold of %s (%.0f%% of block production time %s)",
+			latencyWarning, name, latency, threshold, latencyWarningThreshold*100, lmc.blockProductionRate,
 		)
 	}
 

--- a/evm/logpoller/latency_monitor.go
+++ b/evm/logpoller/latency_monitor.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	latencyWarningThreshold = 0.7 // Warn if latency exceeds 70% of block production rate
-	latencyWarning          = "RPC server is not meeting latency requirements"
+	latencyWarning          = "RPC latency warning: consider using faster endpoints or reviewing network conditions"
 )
 
 type LatencyMonitorClient interface {
@@ -51,7 +51,7 @@ func latencyMonitoredCall[T any](lm *LatencyMonitor, name string, fn func() (T, 
 	threshold := time.Duration(float64(lm.blockProductionRate) * latencyWarningThreshold)
 	if latency > threshold {
 		lm.lggr.Warnf(
-			"%s: %s latency of %s exceeded threshold of %s (%.0f%% of block production time %s)",
+			"%s - %s latency of %s exceeded threshold of %s (%.0f%% of block production time %s)",
 			latencyWarning, name, latency, threshold, latencyWarningThreshold*100, lm.blockProductionRate,
 		)
 	}

--- a/evm/logpoller/latency_monitor.go
+++ b/evm/logpoller/latency_monitor.go
@@ -27,18 +27,21 @@ type LatencyMonitorTracker interface {
 
 // LatencyMonitor wraps RPC calls with a warning if the latency exceeds the set threshold of block production rate
 type LatencyMonitor struct {
-	c                   LatencyMonitorClient
-	t                   LatencyMonitorTracker
-	lggr                logger.Logger
-	blockProductionRate time.Duration
+	c    LatencyMonitorClient
+	t    LatencyMonitorTracker
+	lggr logger.Logger
+
+	blockProductionRate     time.Duration
+	latencyWarningThreshold float64
 }
 
-func NewLatencyMonitor(c LatencyMonitorClient, t LatencyMonitorTracker, lggr logger.Logger, blockProductionRate time.Duration) LatencyMonitor {
+func NewLatencyMonitor(c LatencyMonitorClient, t LatencyMonitorTracker, lggr logger.Logger, opts Opts) LatencyMonitor {
 	return LatencyMonitor{
-		c:                   c,
-		t:                   t,
-		lggr:                lggr,
-		blockProductionRate: blockProductionRate,
+		c:                       c,
+		t:                       t,
+		lggr:                    lggr,
+		blockProductionRate:     opts.PollPeriod,
+		latencyWarningThreshold: opts.LatencyWarningThreshold,
 	}
 }
 

--- a/evm/logpoller/latency_monitor.go
+++ b/evm/logpoller/latency_monitor.go
@@ -1,0 +1,81 @@
+package logpoller
+
+import (
+	"context"
+	"math/big"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-integrations/evm/types"
+)
+
+const latencyWarningThreshold = 0.7 // Warn if latency exceeds 70% of block production rate
+
+type LatencyMonitorClient interface {
+	HeadByNumber(ctx context.Context, n *big.Int) (*types.Head, error)
+	HeadByHash(ctx context.Context, n common.Hash) (*types.Head, error)
+}
+
+type LatencyMonitorTracker interface {
+	LatestAndFinalizedBlock(ctx context.Context) (latest *types.Head, finalized *types.Head, err error)
+}
+
+// LatencyMonitor wraps RPC calls with a warning if the latency exceeds the set threshold of block production rate
+type LatencyMonitor struct {
+	c                   LatencyMonitorClient
+	t                   LatencyMonitorTracker
+	lggr                logger.Logger
+	blockProductionRate time.Duration
+}
+
+func NewLatencyMonitor(c LatencyMonitorClient, t LatencyMonitorTracker, lggr logger.Logger, blockProductionRate time.Duration) LatencyMonitor {
+	return LatencyMonitor{
+		c:                   c,
+		t:                   t,
+		lggr:                lggr,
+		blockProductionRate: blockProductionRate,
+	}
+}
+
+// latencyMonitoredCall wraps any function and logs a warning if it exceeds the threshold of block production rate
+func latencyMonitoredCall[T any](lmc *LatencyMonitor, name string, fn func() (T, error)) (T, error) {
+	start := time.Now()
+	result, err := fn()
+	latency := time.Since(start)
+
+	threshold := time.Duration(float64(lmc.blockProductionRate) * latencyWarningThreshold)
+	if latency > threshold {
+		lmc.lggr.Warnf(
+			"%s latency of %s exceeded threshold of %s (%.0f%% of block production time %s)",
+			name, latency, threshold, latencyWarningThreshold*100, lmc.blockProductionRate,
+		)
+	}
+
+	return result, err
+}
+
+func (lmc *LatencyMonitor) HeadByNumber(ctx context.Context, n *big.Int) (*types.Head, error) {
+	return latencyMonitoredCall(lmc, "HeadByNumber", func() (*types.Head, error) {
+		return lmc.c.HeadByNumber(ctx, n)
+	})
+}
+
+func (lmc *LatencyMonitor) HeadByHash(ctx context.Context, n common.Hash) (*types.Head, error) {
+	return latencyMonitoredCall(lmc, "HeadByHash", func() (*types.Head, error) {
+		return lmc.c.HeadByHash(ctx, n)
+	})
+}
+
+func (lmc *LatencyMonitor) LatestAndFinalizedBlock(ctx context.Context) (latest *types.Head, finalized *types.Head, err error) {
+	type HeadPair struct {
+		Latest    *types.Head
+		Finalized *types.Head
+	}
+	pair, err := latencyMonitoredCall(lmc, "LatestAndFinalizedBlock", func() (HeadPair, error) {
+		latest, finalized, err := lmc.t.LatestAndFinalizedBlock(ctx)
+		return HeadPair{latest, finalized}, err
+	})
+	return pair.Latest, pair.Finalized, err
+}

--- a/evm/logpoller/latency_monitor.go
+++ b/evm/logpoller/latency_monitor.go
@@ -71,7 +71,7 @@ func (lmc *LatencyMonitor) HeadByHash(ctx context.Context, n common.Hash) (*type
 	})
 }
 
-func (lmc *LatencyMonitor) LatestAndFinalizedBlock(ctx context.Context) (latest *types.Head, finalized *types.Head, err error) {
+func (lmc *LatencyMonitor) LatestAndFinalizedBlock(ctx context.Context) (*types.Head, *types.Head, error) {
 	type HeadPair struct {
 		Latest    *types.Head
 		Finalized *types.Head

--- a/evm/logpoller/latency_monitor.go
+++ b/evm/logpoller/latency_monitor.go
@@ -43,16 +43,16 @@ func NewLatencyMonitor(c LatencyMonitorClient, t LatencyMonitorTracker, lggr log
 }
 
 // latencyMonitoredCall wraps any function and logs a warning if it exceeds the threshold of block production rate
-func latencyMonitoredCall[T any](lmc *LatencyMonitor, name string, fn func() (T, error)) (T, error) {
+func latencyMonitoredCall[T any](lm *LatencyMonitor, name string, fn func() (T, error)) (T, error) {
 	start := time.Now()
 	result, err := fn()
 	latency := time.Since(start)
 
-	threshold := time.Duration(float64(lmc.blockProductionRate) * latencyWarningThreshold)
+	threshold := time.Duration(float64(lm.blockProductionRate) * latencyWarningThreshold)
 	if latency > threshold {
-		lmc.lggr.Warnf(
+		lm.lggr.Warnf(
 			"%s: %s latency of %s exceeded threshold of %s (%.0f%% of block production time %s)",
-			latencyWarning, name, latency, threshold, latencyWarningThreshold*100, lmc.blockProductionRate,
+			latencyWarning, name, latency, threshold, latencyWarningThreshold*100, lm.blockProductionRate,
 		)
 	}
 

--- a/evm/logpoller/latency_monitor_test.go
+++ b/evm/logpoller/latency_monitor_test.go
@@ -44,7 +44,12 @@ func TestLatencyMonitor(t *testing.T) {
 	client := &mockClient{}
 	tracker := &mockTracker{}
 
-	lm := logpoller.NewLatencyMonitor(client, tracker, lggr, blockProductionRate)
+	opts := logpoller.Opts{
+		PollPeriod:              blockProductionRate,
+		LatencyWarningThreshold: 0.7,
+	}
+
+	lm := logpoller.NewLatencyMonitor(client, tracker, lggr, opts)
 
 	// Slow client with latency 80% of block production rate
 	client.latency = time.Duration(0.8 * float64(blockProductionRate))

--- a/evm/logpoller/latency_monitor_test.go
+++ b/evm/logpoller/latency_monitor_test.go
@@ -1,0 +1,65 @@
+package logpoller_test
+
+import (
+	"context"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/smartcontractkit/chainlink-integrations/evm/logpoller"
+	"github.com/smartcontractkit/chainlink-integrations/evm/types"
+)
+
+type mockClient struct {
+	latency time.Duration
+}
+
+func (c *mockClient) HeadByNumber(_ context.Context, _ *big.Int) (*types.Head, error) {
+	time.Sleep(c.latency)
+	return nil, nil
+}
+
+func (c *mockClient) HeadByHash(_ context.Context, _ common.Hash) (*types.Head, error) {
+	time.Sleep(c.latency)
+	return nil, nil
+}
+
+type mockTracker struct {
+	latency time.Duration
+}
+
+func (t *mockTracker) LatestAndFinalizedBlock(_ context.Context) (*types.Head, *types.Head, error) {
+	time.Sleep(t.latency)
+	return nil, nil, nil
+}
+
+func TestLatencyMonitor(t *testing.T) {
+	lggr, logs := logger.TestObserved(t, zapcore.DebugLevel)
+	blockProductionRate := 250 * time.Millisecond
+	client := &mockClient{}
+	tracker := &mockTracker{}
+
+	lm := logpoller.NewLatencyMonitor(client, tracker, lggr, blockProductionRate)
+
+	// Slow client with latency 80% of block production rate
+	client.latency = time.Duration(0.8 * float64(blockProductionRate))
+	tracker.latency = time.Duration(0.8 * float64(blockProductionRate))
+	_, _ = lm.HeadByNumber(t.Context(), nil)
+	_, _ = lm.HeadByHash(t.Context(), common.Hash{})
+	_, _, _ = lm.LatestAndFinalizedBlock(t.Context())
+	require.Equal(t, 3, logs.Len())
+	_ = logs.TakeAll()
+
+	// fast client should not log warnings
+	client.latency = 0
+	tracker.latency = 0
+	_, _ = lm.HeadByNumber(t.Context(), nil)
+	_, _ = lm.HeadByHash(t.Context(), common.Hash{})
+	_, _, _ = lm.LatestAndFinalizedBlock(t.Context())
+	require.Equal(t, 0, logs.Len())
+}

--- a/evm/logpoller/latency_monitor_test.go
+++ b/evm/logpoller/latency_monitor_test.go
@@ -7,10 +7,10 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-integrations/evm/logpoller"
 	"github.com/smartcontractkit/chainlink-integrations/evm/types"
 )

--- a/evm/logpoller/log_poller.go
+++ b/evm/logpoller/log_poller.go
@@ -168,7 +168,7 @@ func NewLogPoller(orm ORM, ec Client, lggr logger.Logger, headTracker HeadTracke
 		ec:                       ec,
 		orm:                      orm,
 		headTracker:              headTracker,
-		latencyMonitor:           LatencyMonitor{ec, headTracker, lggr, opts.PollPeriod},
+		latencyMonitor:           NewLatencyMonitor(ec, headTracker, lggr, opts.PollPeriod),
 		lggr:                     logger.Sugared(logger.Named(lggr, "LogPoller")),
 		replayStart:              make(chan int64),
 		replayComplete:           make(chan error),

--- a/evm/logpoller/log_poller.go
+++ b/evm/logpoller/log_poller.go
@@ -149,6 +149,7 @@ type Opts struct {
 	KeepFinalizedBlocksDepth int64
 	BackupPollerBlockDelay   int64
 	LogPrunePageSize         int64
+	LatencyWarningThreshold  float64
 	ClientErrors             config.ClientErrors
 }
 
@@ -168,7 +169,7 @@ func NewLogPoller(orm ORM, ec Client, lggr logger.Logger, headTracker HeadTracke
 		ec:                       ec,
 		orm:                      orm,
 		headTracker:              headTracker,
-		latencyMonitor:           NewLatencyMonitor(ec, headTracker, lggr, opts.PollPeriod),
+		latencyMonitor:           NewLatencyMonitor(ec, headTracker, lggr, opts),
 		lggr:                     logger.Sugared(logger.Named(lggr, "LogPoller")),
 		replayStart:              make(chan int64),
 		replayComplete:           make(chan error),


### PR DESCRIPTION
### Description
Added a LatencyMonitor to log warnings if logpoller RPC calls exceed 70% of block production rate.

Ticket: https://smartcontract-it.atlassian.net/browse/BCFR-1199
