### PR TITLE
added & updated chain configs for multiple chains

### DIFF
--- a/evm/client/errors.go
+++ b/evm/client/errors.go
@@ -300,6 +300,13 @@ var monad = ClientErrors{
 	Fatal: regexp.MustCompile("Gas limit too low"),
 }
 
+var rootstockFatal = regexp.MustCompile(`(: |^)transaction's basic cost is above the gas limit`)
+var rootstock = ClientErrors{
+	TransactionAlreadyInMempool:       regexp.MustCompile(`(: |^)pending transaction with same hash already exists`),
+	ReplacementTransactionUnderpriced: regexp.MustCompile(`(: |^)gas price not enough to bump transaction`),
+	Fatal:                             rootstockFatal,
+}
+
 const TerminallyStuckMsg = "transaction terminally stuck"
 
 // Tx.Error messages that are set internally so they are not chain or client specific
@@ -307,7 +314,7 @@ var internal = ClientErrors{
 	TerminallyStuck: regexp.MustCompile(TerminallyStuckMsg),
 }
 
-var clients = []ClientErrors{parity, geth, arbitrum, metis, substrate, avalanche, nethermind, harmony, besu, erigon, klaytn, celo, zkSync, zkEvm, treasure, mantle, aStar, hedera, gnosis, sei, monad, internal}
+var clients = []ClientErrors{parity, geth, arbitrum, metis, substrate, avalanche, nethermind, harmony, besu, erigon, klaytn, celo, zkSync, zkEvm, treasure, mantle, aStar, hedera, gnosis, sei, monad, rootstock, internal}
 
 // ClientErrorRegexes returns a map of compiled regexes for each error type
 func ClientErrorRegexes(errsRegex config.ClientErrors) *ClientErrors {

--- a/evm/client/errors.go
+++ b/evm/client/errors.go
@@ -300,13 +300,6 @@ var monad = ClientErrors{
 	Fatal: regexp.MustCompile("Gas limit too low"),
 }
 
-var rootstockFatal = regexp.MustCompile(`(: |^)transaction's basic cost is above the gas limit`)
-var rootstock = ClientErrors{
-	TransactionAlreadyInMempool:       regexp.MustCompile(`(: |^)pending transaction with same hash already exists`),
-	ReplacementTransactionUnderpriced: regexp.MustCompile(`(: |^)gas price not enough to bump transaction`),
-	Fatal:                             rootstockFatal,
-}
-
 const TerminallyStuckMsg = "transaction terminally stuck"
 
 // Tx.Error messages that are set internally so they are not chain or client specific
@@ -314,7 +307,7 @@ var internal = ClientErrors{
 	TerminallyStuck: regexp.MustCompile(TerminallyStuckMsg),
 }
 
-var clients = []ClientErrors{parity, geth, arbitrum, metis, substrate, avalanche, nethermind, harmony, besu, erigon, klaytn, celo, zkSync, zkEvm, treasure, mantle, aStar, hedera, gnosis, sei, monad, rootstock, internal}
+var clients = []ClientErrors{parity, geth, arbitrum, metis, substrate, avalanche, nethermind, harmony, besu, erigon, klaytn, celo, zkSync, zkEvm, treasure, mantle, aStar, hedera, gnosis, sei, monad, internal}
 
 // ClientErrorRegexes returns a map of compiled regexes for each error type
 func ClientErrorRegexes(errsRegex config.ClientErrors) *ClientErrors {

--- a/evm/config/toml/defaults/BSC_Mainnet.toml
+++ b/evm/config/toml/defaults/BSC_Mainnet.toml
@@ -12,6 +12,7 @@ NoNewFinalizedHeadsThreshold = '45s'
 
 [GasEstimator]
 PriceDefault = '1 gwei'
+PriceMin = '1 gwei'
 # 15s delay since feeds update every minute in volatile situations
 BumpThreshold = 5
 

--- a/evm/config/toml/defaults/Celo_Mainnet.toml
+++ b/evm/config/toml/defaults/Celo_Mainnet.toml
@@ -1,22 +1,31 @@
 ChainID = '42220'
 ChainType = 'celo'
-FinalityDepth = 10
+FinalityDepth = 2750
+FinalityTagEnabled = true
 LinkContractAddress = '0xd07294e6E917e07dfDcee882dd1e2565085C2ae0'
-LogPollInterval = '5s'
+LogPollInterval = '1s'
 MinIncomingConfirmations = 1
 NoNewHeadsThreshold = '1m'
-OCR.ContractConfirmations = 1
-FinalizedBlockOffset = 2
-NoNewFinalizedHeadsThreshold = '1m'
+NoNewFinalizedHeadsThreshold = '45m'
 
 [GasEstimator]
+EIP1559DynamicFees = true
 PriceDefault = '5 gwei'
 PriceMax = '500 gwei'
 PriceMin = '5 gwei'
 BumpMin = '2 gwei'
 
 [GasEstimator.BlockHistory]
-BlockHistorySize = 12
+BlockHistorySize = 50
+
+[Transactions]
+ResendAfterThreshold = '30s'
 
 [HeadTracker]
-HistoryDepth = 50
+HistoryDepth = 300
+
+[NodePool]
+SyncThreshold = 10 # recommended for OP stack chains
+
+[OCR]
+ContractConfirmations = 1 # recommended for OP stack chains

--- a/evm/config/toml/defaults/Hemi_Testnet.toml
+++ b/evm/config/toml/defaults/Hemi_Testnet.toml
@@ -1,0 +1,40 @@
+ChainID = '743111'
+ChainType = 'optimismBedrock'
+FinalityTagEnabled = true
+LogBroadcasterEnabled = false
+LogPollInterval = '4s'
+MinIncomingConfirmations = 1
+# Blocks are created in batches & sometimes takes upto 2 minutes
+NoNewHeadsThreshold = '3m'
+# Finalization takes upto 22 minutes, added some buffer
+NoNewFinalizedHeadsThreshold = '30m'
+
+[GasEstimator]
+EIP1559DynamicFees = true
+Mode = 'FeeHistory'
+
+[GasEstimator.DAOracle]
+OracleType = 'opstack'
+OracleAddress = '0x420000000000000000000000000000000000000F'
+
+[GasEstimator.FeeHistory]
+# Blocks rate is on anverage of 12-24s 
+CacheTimeout = '10s'
+
+[GasEstimator.BlockHistory]
+# We want to smooth out the gas prices, so we increase the sample size.
+BlockHistorySize = 50
+
+# Blocks are created in batches & sometimes takes upto 2 minutes, increasing this value to avoid resending until the txn is seen
+[Transactions]
+ResendAfterThreshold = '2m'
+
+[HeadTracker]
+FinalityTagBypass = false
+
+[NodePool]
+SyncThreshold = 10
+NewHeadsPollInterval = "4s"
+
+[OCR]
+ContractConfirmations = 1

--- a/evm/config/toml/defaults/Lens_Mainnet.toml
+++ b/evm/config/toml/defaults/Lens_Mainnet.toml
@@ -1,0 +1,22 @@
+ChainID = "232"
+ChainType = "zksync"
+FinalityTagEnabled = true
+LinkContractAddress = '0x2Ea38D6cDb6774992d4A62fe622f4405663729Dd'
+# block rate is dynamic
+LogPollInterval = "5s"
+# traffic is too low & block rate is dynamic, so disabling liveness check temporarily
+NoNewHeadsThreshold = "0"
+
+[GasEstimator]
+Mode = 'FeeHistory'
+BumpThreshold = 1
+BumpPercent = 40
+
+[GasEstimator.FeeHistory]
+CacheTimeout = '5s'
+
+[GasEstimator.DAOracle]
+OracleType = 'zksync'
+
+[Transactions]
+ResendAfterThreshold = '7m0s'

--- a/evm/config/toml/defaults/Lens_Sepolia.toml
+++ b/evm/config/toml/defaults/Lens_Sepolia.toml
@@ -10,17 +10,13 @@ LogPollInterval = "5s"
 NoNewHeadsThreshold = "10m"
 
 [GasEstimator]
-# Increased gasLimit to account for pubdata cost
-LimitDefault = 100_000_000
-# value given by ds&a
-FeeCapDefault = "2000 gwei"
-# estimators typically estimated with min of 75 with median of 86
-PriceDefault = "70 gwei"
-PriceMax = "2000 gwei"
-PriceMin = "70 gwei"
+Mode = 'FeeHistory'
 # bump gas aggressively to avoid high amounts of transmit errors
 BumpThreshold = 1
 BumpPercent = 40
+
+[GasEstimator.FeeHistory]
+CacheTimeout = '5s'
 
 [GasEstimator.DAOracle]
 OracleType = 'zksync'
@@ -31,3 +27,6 @@ ResendAfterThreshold = '7m0s'
 [HeadTracker]
 # l1 batching is done every 8hrs with low network activity setting this value to a rough calculation of ~1tx / 2min * 8hrs
 HistoryDepth = 250
+
+[NodePool.Errors]
+TerminallyUnderpriced = "(?:: |^)(max fee per gas less than block base fee|virtual machine entered unexpected state. (?:P|p)lease contact developers and provide transaction details that caused this error. Error description: (?:The operator included transaction with an unacceptable gas price|Assertion error: Fair pubdata price too high))$"

--- a/evm/config/toml/defaults/Linea_Mainnet.toml
+++ b/evm/config/toml/defaults/Linea_Mainnet.toml
@@ -6,6 +6,7 @@ LinkContractAddress = '0xa18152629128738a5c081eb226335FEd4B9C95e9'
 NoNewHeadsThreshold = '0'
 
 [GasEstimator]
+BumpMin = '500 mwei'
 BumpPercent = 40
 PriceMin = '400 mwei'
 

--- a/evm/config/toml/defaults/Mind_Mainnet.toml
+++ b/evm/config/toml/defaults/Mind_Mainnet.toml
@@ -1,0 +1,16 @@
+ChainID = '228'
+ChainType = 'arbitrum'
+FinalityTagEnabled = true
+LogPollInterval = '2s' # max 4 blocks per second, adding slight buffer
+
+[GasEstimator]
+EIP1559DynamicFees = false
+Mode = 'Arbitrum'
+PriceDefault = '0.005 gwei' # fixed to 0.005 gwei
+PriceMin = '0' # Arbitrum uses the suggested gas price, so we don't want to place any limits on the minimum            
+
+[GasEstimator.DAOracle]
+OracleType = 'arbitrum'
+
+[NodePool]
+SyncThreshold = 10

--- a/evm/config/toml/defaults/Mind_Testnet.toml
+++ b/evm/config/toml/defaults/Mind_Testnet.toml
@@ -1,0 +1,17 @@
+ChainID = '192940'
+ChainType = 'arbitrum'
+FinalityTagEnabled = true
+LinkContractAddress = '0xd8A9246e84903e82CA01e42774b01A7CdD465BFa'
+LogPollInterval = '2s' # max 4 blocks per second, adding slight buffer
+
+[GasEstimator]
+EIP1559DynamicFees = false
+Mode = 'Arbitrum'
+PriceDefault = '0.005 gwei' # fixed to 0.005 gwei
+PriceMin = '0' # Arbitrum uses the suggested gas price, so we don't want to place any limits on the minimum            
+
+[GasEstimator.DAOracle]
+OracleType = 'arbitrum'
+
+[NodePool]
+SyncThreshold = 10


### PR DESCRIPTION
- BSC: Reduced min gasprice to 1 gwei
- Celo : updated configs to reflect testnet after Celo L2 migration
- Added Hemi, Mind testnet configs from testnet & Added Lens_mainnet config
- Lens-sepolia - updated gas estimator
- Linea-Mainnet - NOPs are sending transactions with 5+ gwei when bumped, leading to higher overall costs.reducing to 0.5 gwei to avoid excessive bumping